### PR TITLE
fix(ci): [OPS-723] prevent script injection in gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -19,14 +19,19 @@ jobs:
           persist-credentials: false
       - name: Set scan range
         id: range
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          FORCED: ${{ github.event.forced }}
         run: |
           NULL_SHA="0000000000000000000000000000000000000000"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "log_opts=${{ github.event.pull_request.base.sha }}..HEAD" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.before }}" = "$NULL_SHA" ] || [ -z "${{ github.event.before }}" ] || [ "${{ github.event.forced }}" = "true" ]; then
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "log_opts=${BASE_SHA}..HEAD" >> $GITHUB_OUTPUT
+          elif [ "$BEFORE_SHA" = "$NULL_SHA" ] || [ -z "$BEFORE_SHA" ] || [ "$FORCED" = "true" ]; then
             echo "log_opts=" >> $GITHUB_OUTPUT
           else
-            echo "log_opts=${{ github.event.before }}..HEAD" >> $GITHUB_OUTPUT
+            echo "log_opts=${BEFORE_SHA}..HEAD" >> $GITHUB_OUTPUT
           fi
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:


### PR DESCRIPTION
## Summary
- Move `${{ }}` expressions from `run:` block to `env:` block in `gitleaks.yaml` to prevent potential shell injection
- Uses safe env-var pattern recommended by GitHub security guidelines
- Defense-in-depth: while current values (event_name, SHAs, booleans) are not attacker-controllable, the `env:` pattern eliminates the class of vulnerability entirely

## Test plan
- [ ] Verify YAML is valid (checked locally)
- [ ] Verify zero `${{ }}` remain in any `run:` block (checked locally)
- [ ] Gitleaks CI still runs correctly on this PR

Jira: https://knostic.atlassian.net/browse/OPS-723

🤖 Generated with [Claude Code](https://claude.com/claude-code)